### PR TITLE
Use singular and plural labels if defined

### DIFF
--- a/src/NestedForm.php
+++ b/src/NestedForm.php
@@ -190,8 +190,8 @@ class NestedForm extends Field implements RelatableField
         $this->resourceClass = $resource;
         $this->resourceName = $resource::uriKey();
         $this->viaRelationship = $this->attribute;
-        $this->singularLabel = Str::singular($this->name);
-        $this->pluralLabel = Str::plural($this->name);
+        $this->singularLabel = $this->singularLabel ?? Str::singular($this->name);
+        $this->pluralLabel = $this->pluralLabel ?? Str::plural($this->name);
         $this->keyName = (new $this->resourceClass::$model)->getKeyName();
         $this->viaResource = app(NovaRequest::class)->route('resource');
         $this->returnContext = $this;


### PR DESCRIPTION
If you define a singular and/or plural label they will no longer be overridden.